### PR TITLE
Support for submitting a FHIR death record to an EDRS

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react-dom": "^16.2.0",
     "react-scripts": "1.1.0",
     "semantic-ui-css": "^2.3.1",
-    "semantic-ui-react": "^0.79.0"
+    "semantic-ui-react": "^0.79.0",
+    "uuid": "^3.2.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/AdditionalQuestionsForm.js
+++ b/src/AdditionalQuestionsForm.js
@@ -21,24 +21,24 @@ class AdditionalQuestionsForm extends FormPage {
               <Form.Field>
                 <label>Was an Autopsy Performed?</label>
               </Form.Field>
-              {this.radio('Yes', 'autopsyPerformed', 'yes')}
-              {this.radio('No', 'autopsyPerformed', 'no')}
+              {this.radio('Yes', 'autopsyPerformed', 'Yes')}
+              {this.radio('No', 'autopsyPerformed', 'No')}
 
               <Form.Field>
                 <label>Were Autopsy Findings Available to Complete the Case of Death?</label>
               </Form.Field>
-              {this.radio('Yes', 'autopsyAvailable', 'yes')}
-              {this.radio('No', 'autopsyAvailable', 'no')}
+              {this.radio('Yes', 'autopsyAvailable', 'Yes')}
+              {this.radio('No', 'autopsyAvailable', 'No')}
 
               <Form.Field>
                 <label>Manner of Death:</label>
               </Form.Field>
-              {this.radio('Natural', 'mannerOfDeath', '38605008')}
-              {this.radio('Homicide', 'mannerOfDeath', '27935005')}
-              {this.radio('Accident', 'mannerOfDeath', '7878000')}
-              {this.radio('Suicide', 'mannerOfDeath', '44301001')}
-              {this.radio('Pending Investigation', 'mannerOfDeath', '185973002')}
-              {this.radio('Could not be Determined', 'mannerOfDeath', '65037004')}
+              {this.radio('Natural', 'mannerOfDeath', 'Natural')}
+              {this.radio('Homicide', 'mannerOfDeath', 'Homicide')}
+              {this.radio('Accident', 'mannerOfDeath', 'Accident')}
+              {this.radio('Suicide', 'mannerOfDeath', 'Suicide')}
+              {this.radio('Pending Investigation', 'mannerOfDeath', 'Pending Investigation')}
+              {this.radio('Could not be Determined', 'mannerOfDeath', 'Could not be determined')}
             </Form>
 
           </Grid.Column>
@@ -48,19 +48,19 @@ class AdditionalQuestionsForm extends FormPage {
               <Form.Field>
                 <label>Did tobacco use contribute to death?</label>
               </Form.Field>
-              {this.radio('Yes', 'tobacco', '373066001')}
-              {this.radio('No', 'tobacco', '373067005')}
-              {this.radio('Probably', 'tobacco', '2931005')}
-              {this.radio('Unknown', 'tobacco', 'UNK')}
+              {this.radio('Yes', 'tobacco', 'Yes')}
+              {this.radio('No', 'tobacco', 'No')}
+              {this.radio('Probably', 'tobacco', 'Probably')}
+              {this.radio('Unknown', 'tobacco', 'Unknown')}
 
               <Form.Field>
                 <label>If female:</label>
               </Form.Field>
-              {this.radio('Not pregnant within past year', 'pregnancy', 'PHC1260')}
-              {this.radio('Pregnant at time of death', 'pregnancy', 'PHC1261')}
-              {this.radio('Not pregnant, but pregnant within 42 days of death', 'pregnancy', 'PHC1262')}
-              {this.radio('Not pregnant, but pregnant 43 days to 1 year before death', 'pregnancy', 'PHC1263')}
-              {this.radio('Unknown if pregnant within the past year', 'pregnancy', 'PHC1264')}
+              {this.radio('Not pregnant within past year', 'pregnancy', 'Not pregnant within past year')}
+              {this.radio('Pregnant at time of death', 'pregnancy', 'Pregnant at time of death')}
+              {this.radio('Not pregnant, but pregnant within 42 days of death', 'pregnancy', 'Not pregnant, but pregnant within 42 days of death')}
+              {this.radio('Not pregnant, but pregnant 43 days to 1 year before death', 'pregnancy', 'Not pregnant, but pregnant 43 days to 1 year before death')}
+              {this.radio('Unknown if pregnant within the past year', 'pregnancy', 'Unknown if pregnant within the past year')}
 
               {this.nextStepButton('InjuryQuestions')}
             </Form>

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,6 @@ import AdditionalQuestionsForm from './AdditionalQuestionsForm';
 import InjuryQuestionsForm from './InjuryQuestionsForm';
 import ReviewAndSubmit from './ReviewAndSubmit';
 import { SMARTWrap } from './FHIRClientWrapper';
-import FH from './FHIRExport';
 
 class App extends Component {
 
@@ -50,6 +49,7 @@ class App extends Component {
       timeOfInjury: '',
       placeOfInjury: '',
       injuryAtWork: null,
+      transportationInjury: null,
       locationOfInjuryState: '',
       locationOfInjuryCity: '',
       locationOfInjuryStreet: '',
@@ -193,6 +193,7 @@ class App extends Component {
       case 'ReviewAndSubmit':
         return <ReviewAndSubmit patient={this.state.patient}
                                 gotoStep={this.gotoStep}
+                                handleRecordChange={this.handleRecordChange}
                                 record={this.state.record} />;
       case 'Welcome':
       default:

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import AdditionalQuestionsForm from './AdditionalQuestionsForm';
 import InjuryQuestionsForm from './InjuryQuestionsForm';
 import ReviewAndSubmit from './ReviewAndSubmit';
 import { SMARTWrap } from './FHIRClientWrapper';
+import FH from './FHIRExport';
 
 class App extends Component {
 

--- a/src/App.js
+++ b/src/App.js
@@ -50,6 +50,7 @@ class App extends Component {
       placeOfInjury: '',
       injuryAtWork: null,
       transportationInjury: null,
+      howInjuryOccurred: '',
       locationOfInjuryState: '',
       locationOfInjuryCity: '',
       locationOfInjuryStreet: '',

--- a/src/App.js
+++ b/src/App.js
@@ -87,8 +87,12 @@ class App extends Component {
     // Pull information on decedent from patient to populate fields
     this.setState((prevState) => {
       const newRecord = Object.assign({}, prevState.record);
-      newRecord.actualDeathDate = patient.deceasedDate;
-      newRecord.actualDeathTime = patient.deceasedTime;
+      if (patient.deceasedDate) {
+        newRecord.actualDeathDate = patient.deceasedDate;
+      }
+      if (patient.deceasedTime) {
+        newRecord.actualDeathTime = patient.deceasedTime;
+      }
       return ({ record: newRecord });
     });
   }

--- a/src/FHIRExport.js
+++ b/src/FHIRExport.js
@@ -311,7 +311,7 @@ class InjuryAssociatedWithTransport extends Observation {
       this.valueCodeableConcept = new CodeableConcept('http://hl7.org/fhir/v3/NullFlavor', 'OTH', value);
       break;
     default:
-      throw `InjuryAssociatedWithTransport ${value} not in value set`;
+      throw new Error(`InjuryAssociatedWithTransport ${value} not in value set`);
     }
     this.subject = { reference: subjectEntry.fullUrl };
     this.setProfile('http://nightingaleproject.github.io/fhirDeathRecord/StructureDefinition/sdr-causeOfDeath-DeathFromTransportInjury');
@@ -368,7 +368,7 @@ class MannerOfDeath extends Observation {
       this.valueCodeableConcept = new CodeableConcept('http://snomed.info/sct', '65037004', value);
       break;
     default:
-      throw `MannerOfDeath ${value} not in value set`;
+      throw new Error(`MannerOfDeath ${value} not in value set`);
     }
     this.subject = { reference: subjectEntry.fullUrl };
     this.setProfile('http://nightingaleproject.github.io/fhirDeathRecord/StructureDefinition/sdr-causeOfDeath-MannerOfDeath');
@@ -406,7 +406,7 @@ class TimingOfPregnancy extends Observation {
       this.valueCodeableConcept = new CodeableConcept(null, 'PHC1264', value);
       break;
     default:
-      throw `TimingOfPregnancy ${value} not in value set`;
+      throw new Error(`TimingOfPregnancy ${value} not in value set`);
     }
     this.subject = { reference: subjectEntry.fullUrl };
     this.setProfile('http://nightingaleproject.github.io/fhirDeathRecord/StructureDefinition/sdr-causeOfDeath-TimingOfRecentPregnancyInRelationToDeath');
@@ -431,7 +431,7 @@ class TobaccoUseContributedToDeath extends Observation {
       this.valueCodeableConcept = new CodeableConcept('http://hl7.org/fhir/v3/NullFlavor', 'UNK', value);
       break;
     default:
-      throw `TobaccoUseContributedToDeath ${value} not in value set`;
+      throw new Error(`TobaccoUseContributedToDeath ${value} not in value set`);
     }
     this.subject = { reference: subjectEntry.fullUrl };
     this.setProfile('http://nightingaleproject.github.io/fhirDeathRecord/StructureDefinition/sdr-causeOfDeath-TobaccoUseContributedToDeath');
@@ -508,74 +508,187 @@ class DeathRecord extends Bundle {
   }
 }
 
-// TODO: Just for local testing during development
-const x = new DeathRecord({
-  id: '1',
-  actualOrPresumedDateOfDeath: moment().format(),
-  autopsyPerformed: false,
-  autopsyResultsAvailable: false,
-  datePronouncedDead: moment().format(),
-  deathFromWorkInjury: false,
-  injuryAssociatedWithTransport: 'Other',
-  detailsOfInjury: {
-    value: 'Example details of injury',
-    effectiveDateTime: moment().format(),
-    placeOfInjury: 'Example place of injury',
-    address: {
-      line: [
-        "7 Example Street"
-      ],
-      city: "Bedford",
-      state: "Massachusetts",
-      postalCode: "01730",
-      country: "United States"
-    },
-  },
-  mannerOfDeath: 'Accident',
-  medicalExaminerOrCoronerContacted: false,
-  timingOfPregnancy: 'Not pregnant within past year',
-  tobaccoUseContributedToDeath: 'No',
-  causeOfDeath: [
-    { literalText: 'Example Immediate COD', onsetString: 'minutes' },
-    { literalText: 'Example Underlying COD 1', onsetString: '2 hours' },
-    { literalText: 'Example Underlying COD 2', onsetString: '6 months' },
-    { literalText: 'Example Underlying COD 3', onsetString: '15 years' }
-  ],
-  decedent: {
-    name: 'Example Middle Person',
-    birthDate: '1970-04-24',
-    deceasedDateTime: '2018-04-24T00:00:00+00:00',
-    address:  {
-      line: [
-        "1 Example Street"
-      ],
-      city: "Boston",
-      state: "Massachusetts",
-      postalCode: "02101",
-      country: "United States"
-    },
-    gender: 'male',
-    ssn: '111223333',
-    servedInArmedForces: false,
-    birthSex: 'M'
-  },
-  certifier: {
-    name: 'Example Middle Doctor',
-    certifierType: 'Physician (Pronouncer and Certifier)',
-    identifier: '1',
-    address:  {
-      line: [
-        "100 Example St."
-      ],
-      city: "Bedford",
-      state: "Massachusetts",
-      postalCode: "01730",
-      country: "United States"
-    },
+// An example, which can be used for testing if uncommented
+
+// const example = new DeathRecord({
+//   id: '1',
+//   actualOrPresumedDateOfDeath: moment().format(),
+//   autopsyPerformed: false,
+//   autopsyResultsAvailable: false,
+//   datePronouncedDead: moment().format(),
+//   deathFromWorkInjury: false,
+//   injuryAssociatedWithTransport: 'Other',
+//   detailsOfInjury: {
+//     value: 'Example details of injury',
+//     effectiveDateTime: moment().format(),
+//     placeOfInjury: 'Example place of injury',
+//     address: {
+//       line: [
+//         "7 Example Street"
+//       ],
+//       city: "Bedford",
+//       state: "Massachusetts",
+//       postalCode: "01730",
+//       country: "United States"
+//     },
+//   },
+//   mannerOfDeath: 'Accident',
+//   medicalExaminerOrCoronerContacted: false,
+//   timingOfPregnancy: 'Not pregnant within past year',
+//   tobaccoUseContributedToDeath: 'No',
+//   causeOfDeath: [
+//     { literalText: 'Example Immediate COD', onsetString: 'minutes' },
+//     { literalText: 'Example Underlying COD 1', onsetString: '2 hours' },
+//     { literalText: 'Example Underlying COD 2', onsetString: '6 months' },
+//     { literalText: 'Example Underlying COD 3', onsetString: '15 years' }
+//   ],
+//   decedent: {
+//     name: 'Example Middle Person',
+//     birthDate: '1970-04-24',
+//     deceasedDateTime: '2018-04-24T00:00:00+00:00',
+//     address:  {
+//       line: [
+//         "1 Example Street"
+//       ],
+//       city: "Boston",
+//       state: "Massachusetts",
+//       postalCode: "02101",
+//       country: "United States"
+//     },
+//     gender: 'male',
+//     ssn: '111223333',
+//     servedInArmedForces: false,
+//     birthSex: 'M'
+//   },
+//   certifier: {
+//     name: 'Example Middle Doctor',
+//     certifierType: 'Physician (Pronouncer and Certifier)',
+//     identifier: '1',
+//     address:  {
+//       line: [
+//         "100 Example St."
+//       ],
+//       city: "Bedford",
+//       state: "Massachusetts",
+//       postalCode: "01730",
+//       country: "United States"
+//     },
+//   }
+// });
+
+
+// In the code below we rely on "" evaluating to false
+
+const formatDateAndTime = (date, time) => {
+  if (date && time) {
+    return moment(`${date} ${time}`, 'YYYY-MM-DD HH:mm').format();
+  } else if (date) {
+    return moment(date, 'YYYY-MM-DD').format();
   }
-});
+}
 
+const formatAddress = (street, city, state, zip) => {
+  let address = null;
+  if (street || city || state || zip) {
+    address = {};
+    if (street) {
+      address.line = [street];
+    }
+    if (city) {
+      address.city = city;
+    }
+    if (state) {
+      address.state = state;
+    }
+    if (zip) {
+      address.postalCode = zip;
+    }
+  }
+  return address;
+}
 
-debugger
+const recordToFHIR = (record, decedent) => {
 
-export { DeathRecord };
+  // TODO Consider changing switches above to lookup table approach
+  // TODO Consider using lookup table approach for 'Yes' and 'No' answers so we can just pass through
+  // TODO Consider routing all the decedent information through the record
+
+  // Build the input for translation to FHIR
+  const fhirInput = {};
+
+  fhirInput.actualOrPresumedDateOfDeath = formatDateAndTime(record.actualDeathDate, record.actualDeathTime);
+
+  fhirInput.datePronouncedDead = formatDateAndTime(record.pronouncedDeathDate, record.pronouncedDeathTime);
+
+  if (!_.isNil(record.autopsyPerformed)) {
+    fhirInput.autopsyPerformed = record.autopsyPerformed === 'Yes';
+  }
+
+  if (!_.isNil(record.autopsyAvailable)) {
+    fhirInput.autopsyResultsAvailable = record.autopsyAvailable === 'Yes';
+  }
+
+  if (!_.isNil(record.injuryAtWork)) {
+    fhirInput.deathFromWorkInjury = record.injuryAtWork === 'Yes';
+  }
+
+  fhirInput.injuryAssociatedWithTransport = record.transportationInjury;
+
+  const locationOfInjury = formatAddress(record.locationOfInjuryStreet, record.locationOfInjuryCity,
+                                         record.locationOfInjuryState, record.locationOfInjuryZip);
+  if (record.howInjuryOccurred || locationOfInjury || record.placeOfInjury || record.dateOfInjury) {
+    fhirInput.detailsOfInjury = {};
+    // TODO: Need a field to collect field 43 "describe how injury occurred"
+    if (record.howInjuryOccurred) {
+      fhirInput.detailsOfInjury.value = record.howInjuryOccurred;
+    }
+    if (locationOfInjury) {
+      fhirInput.detailsOfInjury.address = locationOfInjury;
+    }
+    if (record.placeOfInjury) {
+      fhirInput.detailsOfInjury.placeOfInjury = record.placeOfInjury;
+    }
+    if (record.dateOfInjury) {
+      fhirInput.detailsOfInjury.effectiveDateTime = formatDateAndTime(record.dateOfInjury, record.timeOfInjury);
+    }
+  }
+
+  fhirInput.mannerOfDeath = record.mannerOfDeath;
+
+  if (!_.isNil(record.examinerContacted)) {
+    fhirInput.medicalExaminerOrCoronerContacted = record.examinerContacted === 'Yes';
+  }
+
+  fhirInput.timingOfPregnancy = record.pregnancy;
+
+  fhirInput.tobaccoUseContributedToDeath = record.tobacco;
+
+  for (let i = 1; i <= 4; i += 1) {
+    if (record[`cod${i}Text`]) {
+      fhirInput.causeOfDeath = fhirInput.causeOfDeath || [];
+      fhirInput.causeOfDeath.push({ literalText: record.cod1Text, onsetString: record.cod1Time });
+    }
+  }
+
+  fhirInput.decedent = {
+    name: decedent.name,
+    birthDate: decedent.birthDate,
+    deceasedDateTime: formatDateAndTime(record.actualDeathDate, record.actualDeathTime),
+    address: decedent.resource.address[0],
+    gender: decedent.gender
+    //ssn: '111223333'
+    //servedInArmedForces: false,
+    //birthSex: 'M'
+  };
+
+  fhirInput.certifier = {
+    name: record.certifierName,
+    certifierType: 'Physician (Pronouncer and Certifier)',
+    identifier: record.certifierNumber,
+    address: formatAddress(record.certifierStreet, record.certifierCity, record.certifierState, record.certifierZip)
+  }
+
+  return new DeathRecord(fhirInput);
+}
+
+export { recordToFHIR  };

--- a/src/FHIRExport.js
+++ b/src/FHIRExport.js
@@ -246,28 +246,45 @@ class DeathRecord extends Bundle {
     this.addEntry(deathRecordContents);
 
     // Add the decedent and certifier information
-    deathRecordContents.addDecedentReference(this.createAndAdd(options.decedent, Decedent));
-    deathRecordContents.addCertifierReference(this.createAndAdd(options.certifier, Certifier));
+    this.addDecedent(options.decedent, deathRecordContents);
+    this.addCertifier(options.certifier, deathRecordContents);
 
     // Add the cause of death information
     options.causeOfDeath = options.causeOfDeath || [];
-    for (let cod of options.causeOfDeath) {
-      const causeOfDeath = new CauseOfDeath(cod.literalText, cod.onsetString);
-      this.addEntry(causeOfDeath);
-      deathRecordContents.addReference(causeOfDeath);
-    }
+    options.causeOfDeath.forEach((cod) => this.addCauseOfDeath(cod.literalText, cod.onsetString, deathRecordContents));
 
     // Add all the observations
-    deathRecordContents.addReference(this.createAndAdd(options.autopsyPerformed, AutopsyPerformed));
-    deathRecordContents.addReference(this.createAndAdd(options.autopsyResultsAvailable, AutopsyResultsAvailable));
-    deathRecordContents.addReference(this.createAndAdd(options.mannerOfDeath, MannerOfDeath));
-    deathRecordContents.addReference(this.createAndAdd(options.deathFromWorkInjury, DeathFromWorkInjury));
+    this.addObservation(options.autopsyPerformed, AutopsyPerformed, deathRecordContents);
+    this.addObservation(options.autopsyResultsAvailable, AutopsyResultsAvailable, deathRecordContents);
+    this.addObservation(options.mannerOfDeath, MannerOfDeath,deathRecordContents);
+    this.addObservation(options.deathFromWorkInjury, DeathFromWorkInjury,deathRecordContents);
   }
-  createAndAdd(value, valueClass) {
-    if (!_.isNil(value)) {
-      const object = new valueClass(value);
-      this.addEntry(object);
-      return object;
+  addDecedent(decedent, deathRecordContents) {
+    if (!_.isNil(decedent)) {
+      const decedentResource = new Decedent(decedent);
+      this.addEntry(decedentResource);
+      deathRecordContents.addDecedentReference(decedentResource);
+    }
+  }
+  addCertifier(certifier, deathRecordContents) {
+    if (!_.isNil(certifier)) {
+      const certifierResource = new Certifier(certifier);
+      this.addEntry(certifierResource);
+      deathRecordContents.addCertifierReference(certifierResource);
+    }
+  }
+  addCauseOfDeath(literalText, onsetString, deathRecordContents) {
+    if (!_.isNil(literalText) && !_.isNil(onsetString)) {
+      const causeOfDeathResource = new CauseOfDeath(literalText, onsetString);
+      this.addEntry(causeOfDeathResource);
+      deathRecordContents.addReference(causeOfDeathResource);
+    }
+  }
+  addObservation(observation, observationClass, deathRecordContents) {
+    if (!_.isNil(observation)) {
+      const observationResource = new observationClass(observation);
+      this.addEntry(observationResource);
+      deathRecordContents.addReference(observationResource);
     }
   }
 }

--- a/src/FHIRExport.js
+++ b/src/FHIRExport.js
@@ -1,0 +1,234 @@
+import _ from 'lodash';
+import uuid from 'uuid/v4';
+
+// Infrastructure for creating FHIR death records based on the profile at
+// https://nightingaleproject.github.io/fhir-death-record/guide/index.html
+
+// Begin with classes to represent the core FHIR resources and types that are used to build a death record
+
+class Base {
+  constructor(options = {}) {
+    Object.assign(this, options);
+    this.fullUrl = `urn:uuid:${uuid()}`;
+  }
+  reference() {
+    return { reference: this.fullUrl };
+  }
+  addExtension(extension) {
+    this.extension = this.extension || [];
+    this.extension.push(extension);
+  }
+}
+
+class Bundle extends Base {
+  constructor(options = {}) {
+    super(options)
+    this.resourceType = 'Bundle';
+  }
+  addEntry(entry) {
+    this.entry = this.entry || [];
+    this.entry.push(entry);
+  }
+}
+
+class Composition extends Base {
+  constructor(options = {}) {
+    super(options);
+    this.resourceType = 'Composition';
+  }
+}
+
+class Observation extends Base {
+  constructor(options = {}) {
+    super(options)
+    this.resourceType = 'Observation';
+  }
+}
+
+class Practitioner extends Base {
+  constructor(options = {}) {
+    super(options)
+    this.resourceType = 'Practitioner';
+  }
+  addName(name) {
+    this.name = this.name || [];
+    this.name.push(new HumanName(name));
+  }
+}
+
+class Patient extends Base {
+  constructor(options = {}) {
+    super(options);
+    this.resourceType = 'Patient';
+  }
+  addName(name) {
+    this.name = this.name || [];
+    this.name.push(new HumanName(name));
+  }
+}
+
+class CodableConcept {
+  constructor(system, code, display) {
+    this.coding = [{ system, code, display }];
+    this.text = display;
+  }
+}
+
+class HumanName {
+  constructor(name, use) {
+    // Start with a simple decomposition
+    const match = name.match(/(\S+)\s+(.+)/);
+    const first = match[1];
+    const last = match[2].split(/\s+/);
+    this.use = 'official';
+    this.first = first;
+    this.family = last;
+  }
+}
+
+// Classes to represent specific components of the death record
+
+class DeathRecordContents extends Composition {
+  constructor(options = {}) {
+    super(options);
+    this.type = new CodableConcept('http://loinc.org', '64297-5', 'Death certificate');
+    this.section = {
+      code: new CodableConcept('http://loinc.org', '69453-9', 'Cause of death')
+    };
+  }
+  addDecedentReference(decedent) {
+    if (decedent) {
+      this.subject = decedent.reference();
+    }
+  }
+  addCertifierReference(certifier) {
+    if (certifier) {
+      this.author = certifier.reference();
+    }
+  }
+  addReference(entry) {
+    if (entry) {
+      this.section.entry = this.section.entry || [];
+      this.section.entry.push(entry.reference());
+    }
+  }
+}
+
+class Decedent extends Patient {
+  constructor(options = {}) {
+    const local = ['name', 'servedInArmedForces', 'birthSex'];
+    super(_.omit(options, local));
+    if (options.name) {
+      this.addName(options.name);
+    }
+    if (!_.isNil(options.servedInArmedForces)) {
+      this.addExtension({
+        url: 'http://nightingaleproject.github.io/fhirDeathRecord/StructureDefinition/sdr-decedent-ServedInArmedForces-extension',
+        valueBoolean: options.servedInArmedForces
+      });
+    }
+    if (!_.isNil(options.birthSex)) {
+      this.addExtension({
+        url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex',
+        valueCode: options.birthSex
+      });
+    }
+  }
+}
+
+class Certifier extends Practitioner {
+  constructor(options = {}) {
+    const local = ['name'];
+    super(_.omit(options, local));
+    if (options.name) {
+      this.addName(options.name);
+    }
+  }
+}
+
+class AutopsyPerformed extends Observation {
+  constructor(value) {
+    super();
+    this.code = new CodableConcept('http://loinc.org', '85699-7', 'Autopsy was performed');
+    this.valueBoolean = value;
+  }
+}
+
+class MannerOfDeath extends Observation {
+  constructor(value) {
+    super();
+    this.code = new CodableConcept('http://loinc.org', '69449-7', 'Manner of Death');
+    switch (value) {
+    case 'Natural':
+      this.valueCodableConcept = new CodableConcept('http://snomed.info/sct', '38605008', value);
+      break;
+    case 'Accident':
+      this.valueCodableConcept = new CodableConcept('http://snomed.info/sct', '7878000', value);
+      break;
+    case 'Suicide':
+      this.valueCodableConcept = new CodableConcept('http://snomed.info/sct', '44301001', value);
+      break;
+    case 'Homicide':
+      this.valueCodableConcept = new CodableConcept('http://snomed.info/sct', '27935005', value);
+      break;
+    case 'Pending Investigation':
+      this.valueCodableConcept = new CodableConcept('http://snomed.info/sct', '185973002', value);
+      break;
+    case 'Could not be determined':
+      this.valueCodableConcept = new CodableConcept('http://snomed.info/sct', '65037004', value);
+      break;
+    default:
+      throw `MannerOfDeath ${value} not in value set`;
+    }
+  }
+}
+
+// Top level class to represent the Death Record, which provides the basic interface for creating itself
+
+class DeathRecord extends Bundle {
+  constructor(options = {}) {
+    // Figure out what options we'll handle locally and pass the rest up
+    const local = ['autopsyPerformed', 'mannerOfDeath', 'decedent', 'certifier'];
+    super(_.omit(options, local));
+
+    // Indicate that this Bundle is a document
+    this.type = 'Document';
+
+    // Create the Composition that tracks all the entries
+    const deathRecordContents = new DeathRecordContents();
+    this.addEntry(deathRecordContents);
+
+    // Add the decedent and certifier information
+    deathRecordContents.addDecedentReference(this.createAndAdd(options.decedent, Decedent));
+    deathRecordContents.addCertifierReference(this.createAndAdd(options.certifier, Certifier));
+
+    // Add all the observations
+    deathRecordContents.addReference(this.createAndAdd(options.autopsyPerformed, AutopsyPerformed));
+    deathRecordContents.addReference(this.createAndAdd(options.mannerOfDeath, MannerOfDeath));
+  }
+  createAndAdd(value, valueClass) {
+    if (!_.isNil(value)) {
+      const object = new valueClass(value);
+      this.addEntry(object);
+      return object;
+    }
+  }
+}
+
+const x = new DeathRecord({
+  id: 1,
+  autopsyPerformed: false,
+  mannerOfDeath: 'Natural',
+  decedent: {
+    name: 'Example Decedent',
+    servedInArmedForces: true,
+    birthSex: 'M'
+  },
+  certifier: {
+    name: 'Example Certifier'
+  }
+});
+
+debugger
+
+export { DeathRecord };

--- a/src/FHIRExport.js
+++ b/src/FHIRExport.js
@@ -609,9 +609,9 @@ const formatAddress = (street, city, state, zip) => {
 
 const recordToFHIR = (record, decedent) => {
 
-  // TODO Consider changing switches above to lookup table approach
-  // TODO Consider using lookup table approach for 'Yes' and 'No' answers so we can just pass through
-  // TODO Consider routing all the decedent information through the record
+  // TODO: Consider changing switches above to lookup table approach
+  // TODO: Consider using lookup table approach for 'Yes' and 'No' answers so we can just pass through
+  // TODO: Consider routing all the decedent information through the record
 
   // Build the input for translation to FHIR
   const fhirInput = {};
@@ -638,7 +638,6 @@ const recordToFHIR = (record, decedent) => {
                                          record.locationOfInjuryState, record.locationOfInjuryZip);
   if (record.howInjuryOccurred || locationOfInjury || record.placeOfInjury || record.dateOfInjury) {
     fhirInput.detailsOfInjury = {};
-    // TODO: Need a field to collect field 43 "describe how injury occurred"
     if (record.howInjuryOccurred) {
       fhirInput.detailsOfInjury.value = record.howInjuryOccurred;
     }
@@ -672,10 +671,10 @@ const recordToFHIR = (record, decedent) => {
 
   fhirInput.decedent = {
     name: decedent.name,
-    birthDate: decedent.birthDate,
+    birthDate: decedent.resource.birthDate,
     deceasedDateTime: formatDateAndTime(record.actualDeathDate, record.actualDeathTime),
     address: decedent.resource.address[0],
-    gender: decedent.gender
+    gender: decedent.resource.gender
     //ssn: '111223333'
     //servedInArmedForces: false,
     //birthSex: 'M'

--- a/src/FHIRExport.js
+++ b/src/FHIRExport.js
@@ -137,10 +137,33 @@ class DeathRecordContents extends Composition {
 
 class Decedent extends Patient {
   constructor(options = {}) {
-    const local = ['name', 'servedInArmedForces', 'birthSex'];
+    const local = ['name', 'birthDate', 'deceasedDateTime', 'address', 'gender', 'ssn', 'servedInArmedForces', 'birthSex'];
+
+    // TODO: Missing fields (we only need to implement the ones where we have data from our test patients):
+    // race, ethnicity, ageAtDeath (derive), placeOfBirth, maritalStatus, placeOfDeath, disposition,
+    // education, occupation, motherMaidenName
+
     super(_.omit(options, local));
     if (options.name) {
       this.addName(options.name);
+    }
+    if (options.birthDate) {
+      this.birthDate = options.birthDate;
+    }
+    if (options.deceasedDateTime) {
+      this.deceasedDateTime = options.deceasedDateTime;
+    }
+    if (options.address) {
+      this.address = new Address(options.address);
+    }
+    if (options.gender) {
+      this.gender = options.gender;
+    }
+    if (options.ssn) {
+      this.identifier = {
+        system: 'http://hl7.org/fhir/sid/us-ssn',
+        value: options.ssn
+      };
     }
     if (!_.isNil(options.servedInArmedForces)) {
       this.addExtension({
@@ -148,7 +171,7 @@ class Decedent extends Patient {
         valueBoolean: options.servedInArmedForces
       });
     }
-    if (!_.isNil(options.birthSex)) {
+    if (options.birthSex) {
       this.addExtension({
         url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex',
         valueCode: options.birthSex
@@ -491,8 +514,7 @@ const x = new DeathRecord({
     placeOfInjury: 'Example place of injury',
     address: {
       line: [
-        "7 Example Street",
-        "Bedford Massachusetts 01730"
+        "7 Example Street"
       ],
       city: "Bedford",
       state: "Massachusetts",
@@ -510,6 +532,19 @@ const x = new DeathRecord({
   ],
   decedent: {
     name: 'Example Decedent',
+    birthDate: moment().format('YYYY-MM-DD'),
+    deceasedDateTime: moment().format(),
+    address:  {
+      line: [
+        "9 Example Street"
+      ],
+      city: "Bedford",
+      state: "Massachusetts",
+      postalCode: "01730",
+      country: "United States"
+    },
+    gender: 'M',
+    ssn: '111-22-3333',
     servedInArmedForces: true,
     birthSex: 'M'
   },
@@ -519,8 +554,7 @@ const x = new DeathRecord({
     identifier: '123456',
     address:  {
       line: [
-        "8 Example Street",
-        "Bedford Massachusetts 01730"
+        "8 Example Street"
       ],
       city: "Bedford",
       state: "Massachusetts",

--- a/src/FHIRExport.js
+++ b/src/FHIRExport.js
@@ -95,9 +95,16 @@ class HumanName {
   constructor(name, use) {
     // Start with a simple decomposition
     // TODO: This won't hold up to more complex examples with prefixes and suffixes
-    const match = name.match(/(.+)\s+(\S+)/);
-    this.given = match[1].split(/\s+/);
-    this.family = match[2];
+    let match = name.match(/(.+)\s+(\S+)/);
+    if (match) {
+      this.given = match[1].split(/\s+/);
+      this.family = match[2];
+    } else {
+      match = name.match(/\S+/);
+      if (match) {
+        this.given = [match[0]];
+      }
+    }
     this.use = 'official';
   }
 }

--- a/src/InjuryQuestionsForm.js
+++ b/src/InjuryQuestionsForm.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Grid, Form } from 'semantic-ui-react';
 import FormPage from './FormPage';
 
-// TODO: Need to add field to describe how injury occurred
-
 class InjuryQuestionsForm extends FormPage {
 
   render() {
@@ -84,6 +82,11 @@ class InjuryQuestionsForm extends FormPage {
                   {this.input('text', 'locationOfInjuryZip', { optional: true })}
                 </Form.Field>
               </Form.Group>
+
+              <Form.Field>
+                <label>Describe how injury occurred</label>
+              </Form.Field>
+              {this.textarea('howInjuryOccurred', { optional: true })}
 
               {this.nextStepButton('ReviewAndSubmit')}
 

--- a/src/InjuryQuestionsForm.js
+++ b/src/InjuryQuestionsForm.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Grid, Form } from 'semantic-ui-react';
 import FormPage from './FormPage';
 
+// TODO: Need to add field to describe how injury occurred
+
 class InjuryQuestionsForm extends FormPage {
 
   render() {

--- a/src/InjuryQuestionsForm.js
+++ b/src/InjuryQuestionsForm.js
@@ -36,11 +36,26 @@ class InjuryQuestionsForm extends FormPage {
                 {this.input('text', 'placeOfInjury', { optional: true })}
               </Form.Field>
 
-              <Form.Field>
-                <label>Injury at work?</label>
-              </Form.Field>
-              {this.radio('Yes', 'injuryAtWork', 'yes', { optional: true })}
-              {this.radio('No', 'injuryAtWork', 'no', { optional: true })}
+              <Grid>
+                <Grid.Row>
+                  <Grid.Column width={8}>
+                    <Form.Field>
+                      <label>Injury at work?</label>
+                    </Form.Field>
+                    {this.radio('Yes', 'injuryAtWork', 'Yes', { optional: true })}
+                    {this.radio('No', 'injuryAtWork', 'No', { optional: true })}
+                  </Grid.Column>
+                  <Grid.Column width={8}>
+                    <Form.Field>
+                      <label>If transportation injury, specify</label>
+                    </Form.Field>
+                    {this.radio('Driver/Operator', 'transportationInjury', 'Vehicle driver', { optional: true })}
+                    {this.radio('Passenger', 'transportationInjury', 'Passenger', { optional: true })}
+                    {this.radio('Pedestrian', 'transportationInjury', 'Pedestrian', { optional: true })}
+                    {this.radio('Other', 'transportationInjury', 'Other', { optional: true })}
+                  </Grid.Column>
+                </Grid.Row>
+              </Grid>
 
               <Form.Field>
                 <label>Address of Injury</label>

--- a/src/PronounceForm.js
+++ b/src/PronounceForm.js
@@ -44,8 +44,8 @@ class PronounceForm extends FormPage {
               <Form.Field>
                 <label>Was Medical Examiner or Coroner Contacted?</label>
               </Form.Field>
-              {this.radio('Yes', 'examinerContacted', 'yes')}
-              {this.radio('No', 'examinerContacted', 'no')}
+              {this.radio('Yes', 'examinerContacted', 'Yes')}
+              {this.radio('No', 'examinerContacted', 'No')}
 
               <h2>Person Pronouncing Death</h2>
 

--- a/src/ReviewAndSubmit.js
+++ b/src/ReviewAndSubmit.js
@@ -44,6 +44,8 @@ class ReviewAndSubmit extends FormPage {
       );
     };
 
+    // TODO: Combine some of these lines, such as addresses
+
     return (
       <React.Fragment>
 
@@ -84,6 +86,7 @@ class ReviewAndSubmit extends FormPage {
               {reviewRow('Location of Injury (Street)', record.locationOfInjuryStreet)}
               {reviewRow('Location of Injury (Apt)', record.locationOfInjuryApt)}
               {reviewRow('Location of Injury (Zip)', record.locationOfInjuryZip)}
+              {reviewRow('Describe how injury occurred', record.howInjuryOccurred)}
             </Grid>
 
           </Grid.Column>
@@ -128,6 +131,8 @@ class ReviewAndSubmit extends FormPage {
               </Form.Group>
 
               <Button primary floated='right' onClick={this.handleSubmit}>Submit</Button>
+
+              <Button primary floated='right' onClick={() => console.log(JSON.stringify(recordToFHIR(this.props.record, this.props.patient), null, 2))}>Log FHIR to Console</Button>
 
             </Form>
           </Grid.Column>

--- a/src/ReviewAndSubmit.js
+++ b/src/ReviewAndSubmit.js
@@ -1,9 +1,35 @@
 import React from 'react';
 import { Grid, Message, Form, Button } from 'semantic-ui-react';
 import FormPage from './FormPage';
+import { recordToFHIR } from './FHIRExport';
+// jQuery for AJAX is overkill, but it's already a dependency
+import jQuery from 'jquery';
 
 class ReviewAndSubmit extends FormPage {
+
+  constructor(props) {
+    super(props);
+    this.state = { edrsEndpoint: 'http://localhost:4000/fhir/v1/death_records.json' };
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleSubmit() {
+    const fhirData = recordToFHIR(this.props.record, this.props.patient);
+    jQuery.ajax({
+      url: this.state.edrsEndpoint,
+      type: 'POST',
+      data: JSON.stringify(fhirData),
+      contentType: 'application/json',
+      dataType: 'json',
+      success: (data) => {
+        alert("Successfully posted data to server:\n\n" + JSON.stringify(fhirData, null, 2));
+      }
+    });
+  }
+
   render() {
+
+    const record = this.props.record;
 
     const reviewRow = (title, value) => {
       return (
@@ -28,36 +54,36 @@ class ReviewAndSubmit extends FormPage {
         <Grid.Row>
           <Grid.Column>
             <Grid>
-              {reviewRow('Date Pronounced Dead', this.props.record.pronouncedDeathDate)}
-              {reviewRow('Time Pronounced Dead', this.props.record.pronouncedDeathTime)}
-              {reviewRow('Actual or Presumed Date of Death', this.props.record.actualDeathDate)}
-              {reviewRow('Actual or Presumed Time of Death', this.props.record.actualDeathTime)}
-              {reviewRow('Was Medical Examiner or Coroner Contacted?', this.props.record.examinerContacted)}
-              {reviewRow('Was an Autopsy Performed?', this.props.record.autopsyPerformed)}
-              {reviewRow('Were Autopsy Findings Available to Complete the Cause of Death?', this.props.record.autopsyAvailable)}
-              {reviewRow('Person Pronouncing Death', this.props.record.pronouncerName)}
-              {reviewRow('License Number of Person Pronouncing Death', this.props.record.pronouncerNumber)}
-              {reviewRow('Immediate Cause of Death', this.props.record.cod1Text)}
-              {reviewRow('Approximate Interval', this.props.record.cod1Time)}
-              {reviewRow('Underlying Cause of Death', this.props.record.cod2Text)}
-              {reviewRow('Approximate Interval', this.props.record.cod2Time)}
-              {reviewRow('Underlying Cause of Death', this.props.record.cod3Text)}
-              {reviewRow('Approximate Interval', this.props.record.cod3Time)}
-              {reviewRow('Underlying Cause of Death', this.props.record.cod4Text)}
-              {reviewRow('Approximate Interval', this.props.record.cod4Time)}
-              {reviewRow('Other Significant Conditions Contributing to Death', this.props.record.contributing)}
-              {reviewRow('Did Tobacco Use Contribute to Death?', this.props.record.tobacco)}
-              {reviewRow('Pregnancy Status', this.props.record.pregnancy)}
-              {reviewRow('Manner of Death', this.props.record.mannerOfDeath)}
-              {reviewRow('Date of Injury', this.props.record.dateOfInjury)}
-              {reviewRow('Time of Injury', this.props.record.timeOfInjury)}
-              {reviewRow('Place of Injury', this.props.record.placeOfInjury)}
-              {reviewRow('Injury at Work?', this.props.record.injuryAtWork)}
-              {reviewRow('Location of Injury (State)', this.props.record.locationOfInjuryState)}
-              {reviewRow('Location of Injury (City)', this.props.record.locationOfInjuryCity)}
-              {reviewRow('Location of Injury (Street)', this.props.record.locationOfInjuryStreet)}
-              {reviewRow('Location of Injury (Apt)', this.props.record.locationOfInjuryApt)}
-              {reviewRow('Location of Injury (Zip)', this.props.record.locationOfInjuryZip)}
+              {reviewRow('Date Pronounced Dead', record.pronouncedDeathDate)}
+              {reviewRow('Time Pronounced Dead', record.pronouncedDeathTime)}
+              {reviewRow('Actual or Presumed Date of Death', record.actualDeathDate)}
+              {reviewRow('Actual or Presumed Time of Death', record.actualDeathTime)}
+              {reviewRow('Was Medical Examiner or Coroner Contacted?', record.examinerContacted)}
+              {reviewRow('Was an Autopsy Performed?', record.autopsyPerformed)}
+              {reviewRow('Were Autopsy Findings Available to Complete the Cause of Death?', record.autopsyAvailable)}
+              {reviewRow('Person Pronouncing Death', record.pronouncerName)}
+              {reviewRow('License Number of Person Pronouncing Death', record.pronouncerNumber)}
+              {reviewRow('Immediate Cause of Death', record.cod1Text)}
+              {reviewRow('Approximate Interval', record.cod1Time)}
+              {reviewRow('Underlying Cause of Death', record.cod2Text)}
+              {reviewRow('Approximate Interval', record.cod2Time)}
+              {reviewRow('Underlying Cause of Death', record.cod3Text)}
+              {reviewRow('Approximate Interval', record.cod3Time)}
+              {reviewRow('Underlying Cause of Death', record.cod4Text)}
+              {reviewRow('Approximate Interval', record.cod4Time)}
+              {reviewRow('Other Significant Conditions Contributing to Death', record.contributing)}
+              {reviewRow('Did Tobacco Use Contribute to Death?', record.tobacco)}
+              {reviewRow('Pregnancy Status', record.pregnancy)}
+              {reviewRow('Manner of Death', record.mannerOfDeath)}
+              {reviewRow('Date of Injury', record.dateOfInjury)}
+              {reviewRow('Time of Injury', record.timeOfInjury)}
+              {reviewRow('Place of Injury', record.placeOfInjury)}
+              {reviewRow('Injury at Work?', record.injuryAtWork)}
+              {reviewRow('Location of Injury (State)', record.locationOfInjuryState)}
+              {reviewRow('Location of Injury (City)', record.locationOfInjuryCity)}
+              {reviewRow('Location of Injury (Street)', record.locationOfInjuryStreet)}
+              {reviewRow('Location of Injury (Apt)', record.locationOfInjuryApt)}
+              {reviewRow('Location of Injury (Zip)', record.locationOfInjuryZip)}
             </Grid>
 
           </Grid.Column>
@@ -101,7 +127,7 @@ class ReviewAndSubmit extends FormPage {
                 </Form.Field>
               </Form.Group>
 
-              <Button primary floated='right' onClick={() => alert('No EDRS Configured')}>Submit</Button>
+              <Button primary floated='right' onClick={this.handleSubmit}>Submit</Button>
 
             </Form>
           </Grid.Column>

--- a/src/ReviewAndSubmit.js
+++ b/src/ReviewAndSubmit.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Message, Form, Button } from 'semantic-ui-react';
+import { Grid, Message, Form, Button, Input } from 'semantic-ui-react';
 import FormPage from './FormPage';
 import { recordToFHIR } from './FHIRExport';
 // jQuery for AJAX is overkill, but it's already a dependency
@@ -10,7 +10,12 @@ class ReviewAndSubmit extends FormPage {
   constructor(props) {
     super(props);
     this.state = { edrsEndpoint: 'http://localhost:4000/fhir/v1/death_records.json' };
+    this.handleEndpointChange = this.handleEndpointChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleEndpointChange(event, data) {
+    this.setState({ edrsEndpoint: data.value });
   }
 
   handleSubmit() {
@@ -22,7 +27,10 @@ class ReviewAndSubmit extends FormPage {
       contentType: 'application/json',
       dataType: 'json',
       success: (data) => {
-        alert("Successfully posted data to server:\n\n" + JSON.stringify(fhirData, null, 2));
+        alert("Successfully submitted data to server:\n\n" + JSON.stringify(fhirData, null, 2));
+      },
+      error: (response) => {
+        alert("Failed to submit data to server, error reported: " + response.statusText);
       }
     });
   }
@@ -129,6 +137,11 @@ class ReviewAndSubmit extends FormPage {
                   {this.input('text', 'certifierZip')}
                 </Form.Field>
               </Form.Group>
+
+              <Form.Field>
+                <label>EDRS FHIR Endpoint URL:</label>
+                <Input type='text' name='edrsEndpoint' value={this.state.edrsEndpoint} onChange={this.handleEndpointChange} />
+              </Form.Field>
 
               <Button primary floated='right' onClick={this.handleSubmit}>Submit</Button>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6581,7 +6581,7 @@ uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
This breaks down into a few distinct changes:

1. Added a question allowing certifier to specify type of transportation injury
2. Added a question allowing certifier to specify how an injury occurred
3. Change multiple choice fields to output the specific string rather than a code, and code later
4. Only pull the patient deceased date and time if present to prevent setting fields to null
5. Added code to allow creation of FHIR death records
6. Allow the user to specify the EDRS endpoint for submission of the FHIR death record, for demo purposes only
7. Allow the user to actually submit the FHIR death record
