### PR TITLE
Support standalone SMART on FHIR launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "core-js": "^2.5.6",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "fhirclient": "^0.1.12",
+    "fhirclient": "nightingaleproject/client-js#bugfix",
     "lodash": "^4.17.5",
     "moment": "^2.20.1",
     "react": "^16.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 import Header from './Header';
 import PatientCard from './PatientCard';
 import Welcome from './Welcome';
+import StandalonePatientSearch from './StandalonePatientSearch';
 import PronounceForm from './PronounceForm';
 import CauseOfDeathForm from './CauseOfDeathForm';
 import AdditionalQuestionsForm from './AdditionalQuestionsForm';
@@ -60,6 +61,8 @@ class App extends Component {
     // First page depends on whether we're running in a SMART on FHIR context or not
     if (props.smart) {
       this.state = { step: 'Pronouncing', record: record, selectedConditions: [] };
+    } else if (props.standalone) {
+      this.state = { step: 'StandalonePatientSearch', record: record, selectedConditions: [] };
     } else {
       this.state = { step: 'Welcome', record: record, selectedConditions: [] };
     }
@@ -200,6 +203,8 @@ class App extends Component {
                                 gotoStep={this.gotoStep}
                                 handleRecordChange={this.handleRecordChange}
                                 record={this.state.record} />;
+      case 'StandalonePatientSearch':
+        return <StandalonePatientSearch setPatient={this.setPatient} setResources={this.setResources} gotoStep={this.gotoStep} />;
       case 'Welcome':
       default:
         return <Welcome setPatient={this.setPatient} setResources={this.setResources} gotoStep={this.gotoStep} />;

--- a/src/FHIRClientWrapper.js
+++ b/src/FHIRClientWrapper.js
@@ -20,8 +20,12 @@ const loadPatients = (smart, searchString) => {
   if (searchString.length > 0) {
     searchParams.query = { name: searchString };
   }
-  return smart.api.search(searchParams).then((result) => {
-    return result.data.entry.map((entry) => new Patient(entry.resource));
+  return smart.api.search(searchParams).then((response) => {
+    if (response.data && response.data.entry) {
+      return response.data.entry.map((entry) => new Patient(entry.resource));
+    } else {
+      return [];
+    }
   });
 }
 

--- a/src/FHIRClientWrapper.js
+++ b/src/FHIRClientWrapper.js
@@ -6,9 +6,9 @@ import moment from 'moment';
 
 // Wrap our usage of fhirclient with some simple utilities
 
-// fhirclient seems pretty broken from this perspective, it doesn't
+// fhirclient doesn't seem to play nice with create-react-app: it doesn't
 // export anything and it puts FHIR in window; work around for now
-import nothing from 'fhirclient'; // eslint-disable-line no-unused-vars
+import nothing from 'fhirclient/dist'; // eslint-disable-line no-unused-vars
 const FHIR = window.FHIR;
 
 // Wrap the oauth ready functionality, providing the SMART context, both so that we don't need

--- a/src/FHIRClientWrapper.js
+++ b/src/FHIRClientWrapper.js
@@ -11,54 +11,89 @@ import moment from 'moment';
 import nothing from 'fhirclient'; // eslint-disable-line no-unused-vars
 const FHIR = window.FHIR;
 
+// Some common functions for both basic FHIR and within a SMART context
+
+// Given a SMART context and a search string (which can be blank), returns a promise
+// that provides a list of patients loaded from the server
+const loadPatients = (smart, searchString) => {
+  const searchParams = { type: 'Patient' };
+  if (searchString.length > 0) {
+    searchParams.query = { name: searchString };
+  }
+  return smart.api.search(searchParams).then((result) => {
+    return result.data.entry.map((entry) => new Patient(entry.resource));
+  });
+}
+
+const loadResources = (smart, patientId) => {
+  const getResources = (type) => {
+    // We need to wrap the results of smart.api.search with a real promise, using the jQuery
+    // promise directly results in unexpected behavior
+    return new Promise((resolve) => {
+      return smart.api.search({ type: type, query: { patient: patientId } }).then((response) => {
+        if (response.data.entry) {
+          const resources = response.data.entry.map((entry) => Resource.wrap(entry.resource));
+          resolve(_.sortBy(resources, (resource) => moment(resource.startDate)).reverse());
+        } else {
+          resolve([]);
+        }
+      }, (error) => {
+        resolve([]); // Eat errors for the moment
+      });
+    });
+  };
+
+  // MedicationRequests might have information on which medication in a separate resource
+  const withMedications = (medicationRequests) => {
+    return Promise.all(medicationRequests.map((medicationRequest) => medicationRequest.withMedication(smart)));
+  }
+
+  return Promise.all([getResources('Condition'),
+                      getResources('MedicationRequest').then(withMedications),
+                      getResources('Procedure'),
+                      getResources('Observation')]);
+}
+
+
 const FHIRWrap = {
 
   // Given a FHIR server URL and a search string (which can be blank), returns a promise
   // that provides a list of patients loaded from the server
   loadPatients(fhirServer, searchString) {
     const smart = FHIR.client({ serviceUrl: fhirServer });
-    const searchParams = { type: 'Patient' };
-    if (searchString.length > 0) {
-      searchParams.name = searchString;
-    }
-    return smart.api.search(searchParams).then((result) => {
-      return result.data.entry.map((entry) => new Patient(entry.resource));
-    });
+    return loadPatients(smart, searchString);
   },
 
   // Given a FHIR server URL and a patient, returns a promise that provides the patient's
   // conditions, medications, procedures, and observations loaded from the server
   loadResources(fhirServer, patientId) {
     const smart = FHIR.client({ serviceUrl: fhirServer });
-
-    const getResources = (type) => {
-      // We need to wrap the results of smart.api.search with a real promise, using the jQuery
-      // promise directly results in unexpected behavior
-      return new Promise((resolve) => {
-        return smart.api.search({ type: type, query: { patient: patientId } }).then((response) => {
-          if (response.data.entry) {
-            const resources = response.data.entry.map((entry) => Resource.wrap(entry.resource));
-            resolve(_.sortBy(resources, (resource) => moment(resource.startDate)).reverse());
-          } else {
-            resolve([]);
-          }
-        });
-      });
-    };
-
-    // MedicationRequests might have information on which medication in a separate resource
-    const withMedications = (medicationRequests) => {
-      return Promise.all(medicationRequests.map((medicationRequest) => medicationRequest.withMedication(smart)));
-    }
-
-    return Promise.all([getResources('Condition'),
-                        getResources('MedicationRequest').then(withMedications),
-                        getResources('Procedure'),
-                        getResources('Observation')]);
+    return loadResources(smart, patientId);
   }
 }
 
 const SMARTWrap = {
+
+  // Given a search string (which can be blank), returns a promise
+  // that provides a list of patients loaded from the server
+  loadPatients(searchString) {
+    return new Promise((resolve) => {
+      FHIR.oauth2.ready((smart) => {
+        loadPatients(smart, searchString).then((result) => resolve(result));
+      });
+    });
+  },
+
+  // Given a patient, returns a promise that provides the patient's conditions,
+  // medications, procedures, and observations loaded from the server
+  loadResources(patientId) {
+    return new Promise((resolve) => {
+      FHIR.oauth2.ready((smart) => {
+        loadResources(smart, patientId).then((result) => resolve(result));
+      });
+    });
+  },
+
   // Return a promise that, if the app is loaded in a SMART context, provides the loaded
   // user, patient, conditions, medications, procedures, and observations
   load() {

--- a/src/FHIRClientWrapper.js
+++ b/src/FHIRClientWrapper.js
@@ -62,8 +62,23 @@ const loadResources = (smart, patientId) => {
     return Promise.all(medicationRequests.map((medicationRequest) => medicationRequest.withMedication(smart)));
   }
 
+  // Utility function: resolve an array of promises with the first promise that resolves with a non-empty
+  // result; we use this to support either MedicationRequest or MedicationOrder
+  const any = (promises) => {
+    return new Promise((resolve) => {
+      Promise.all(promises).then((results) => {
+        for (const result of results) {
+          if (result.length > 0) {
+            resolve(result)
+          }
+        }
+        resolve([]);
+      });
+    });
+  }
+
   return Promise.all([getResources('Condition'),
-                      getResources('MedicationRequest').then(withMedications),
+                      any([getResources('MedicationRequest').then(withMedications), getResources('MedicationOrder')]),
                       getResources('Procedure'),
                       getResources('Observation')]);
 }

--- a/src/PatientSearch.js
+++ b/src/PatientSearch.js
@@ -1,0 +1,90 @@
+import React, { Component } from 'react';
+import { Form, Button, Loader, Card } from 'semantic-ui-react';
+import { FHIRWrap, SMARTWrap } from './FHIRClientWrapper';
+
+class PatientSearch extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { decedentName: '' };
+    this.handleChange = this.handleChange.bind(this);
+    this.handleFhirServerChange = this.handleFhirServerChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handlePatientClick = this.handlePatientClick.bind(this);
+  }
+
+  handleChange(event) {
+    const target = event.target;
+    this.setState({
+      [target.name]: target.value
+    });
+  }
+
+  handleFhirServerChange(event) {
+    this.props.updateFhirServer(event.target.value);
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    this.setState({ patients: [] });
+    // The search we use depends on whether we're in a SMART on FHIR context
+    if (this.props.smart) {
+      SMARTWrap.loadPatients(this.state.decedentName).then((patients) => {
+        this.setState({ patients });
+      });
+    } else {
+      FHIRWrap.loadPatients(this.props.fhirServer, this.state.decedentName).then((patients) => {
+        this.setState({ patients });
+      });
+    }
+  }
+
+  handlePatientClick(event, data) {
+    event.preventDefault();
+    const patient = this.state.patients.find((patient) => patient.id === data.id);
+    this.props.handlePatientSelect(patient);
+  }
+
+  render() {
+
+    const patientLink = (patient) => {
+      return <Card key={patient.id} onClick={this.handlePatientClick} id={patient.id} header={patient.name} />;
+    };
+
+    const patientLinks = (patients) => {
+      if (!patients) {
+        return null;
+      } else if (patients.length === 0) {
+        return <Loader active inline='centered' content='Loading' />;
+      } else {
+        return <Card.Group className='patients'>{patients.map(patientLink)}</Card.Group>;
+      }
+    };
+
+    // Allow the user to select the FHIR server, displayed only if we're not in SMART on FHIR mode
+    const fhirServerFormField = (
+      <Form.Field>
+        <label>FHIR server:</label>
+        <input type="text" name="fhirServer" value={this.props.fhirServer} onChange={this.handleFhirServerChange} />
+      </Form.Field>
+    );
+
+    return (
+      <div>
+        <h3>Specify { this.props.smart ? '' : 'FHIR server and' } patient name to search for</h3>
+        <Form onSubmit={this.handleSubmit}>
+          { this.props.smart ? null : fhirServerFormField }
+          <Form.Field>
+            <label>Decedent name:</label>
+            <input type="text" name="decedentName" value={this.state.decedentName} onChange={this.handleChange} />
+          </Form.Field>
+          <Button primary disabled={this.props.fhirServer === ''} type="submit">Search</Button>
+        </Form>
+        {patientLinks(this.state.patients)}
+      </div>
+    );
+  }
+
+}
+
+export default PatientSearch;

--- a/src/PatientSearch.js
+++ b/src/PatientSearch.js
@@ -6,7 +6,7 @@ class PatientSearch extends Component {
 
   constructor(props) {
     super(props);
-    this.state = { decedentName: '' };
+    this.state = { decedentName: '', searching: false };
     this.handleChange = this.handleChange.bind(this);
     this.handleFhirServerChange = this.handleFhirServerChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -26,15 +26,15 @@ class PatientSearch extends Component {
 
   handleSubmit(event) {
     event.preventDefault();
-    this.setState({ patients: [] });
+    this.setState({ patients: [], searching: true });
     // The search we use depends on whether we're in a SMART on FHIR context
     if (this.props.smart) {
       SMARTWrap.loadPatients(this.state.decedentName).then((patients) => {
-        this.setState({ patients });
+        this.setState({ patients, searching: false });
       });
     } else {
       FHIRWrap.loadPatients(this.props.fhirServer, this.state.decedentName).then((patients) => {
-        this.setState({ patients });
+        this.setState({ patients, searching: false });
       });
     }
   }
@@ -52,12 +52,16 @@ class PatientSearch extends Component {
     };
 
     const patientLinks = (patients) => {
-      if (!patients) {
-        return null;
-      } else if (patients.length === 0) {
+      if (this.state.searching) {
         return <Loader active inline='centered' content='Loading' />;
       } else {
-        return <Card.Group className='patients'>{patients.map(patientLink)}</Card.Group>;
+        if (!patients) {
+          return null;
+        } else if (patients.length === 0) {
+          return "No Results Found";
+        } else {
+          return <Card.Group className='patients'>{patients.map(patientLink)}</Card.Group>;
+        }
       }
     };
 

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -20,6 +20,7 @@ class Resource {
       case 'Procedure': return new Procedure(resource);
       case 'Observation': return new Observation(resource);
       case 'MedicationRequest': return new MedicationRequest(resource);
+      case 'MedicationOrder': return new MedicationOrder(resource);
       default: return new Resource(resource);
     }
   }
@@ -118,6 +119,18 @@ class MedicationRequest extends Resource {
     } else {
       return Promise.resolve(new MedicationRequest(this.resource));
     }
+  }
+}
+
+class MedicationOrder extends Resource {
+  get description() {
+    return this.resource.medicationCodeableConcept.coding[0].display;
+  }
+  get startDate() {
+    return this.resource.dateWritten || this.resource.authoredOn;
+  }
+  get endDate() {
+    return this.resource.dateWritten || this.resource.authoredOn;
   }
 }
 

--- a/src/StandalonePatientSearch.js
+++ b/src/StandalonePatientSearch.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react';
+import { SMARTWrap } from './FHIRClientWrapper';
+import PatientSearch from './PatientSearch';
+
+// fhirclient seems pretty broken from this perspective, it doesn't
+// export anything and it puts FHIR in window; work around for now
+import nothing from 'fhirclient'; // eslint-disable-line no-unused-vars
+const FHIR = window.FHIR;
+
+class StandalonePatientSearch extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { fhirServer: '', decedentName: '' };
+    this.handlePatientSelect = this.handlePatientSelect.bind(this);
+  }
+
+  componentWillMount() {
+    FHIR.oauth2.ready((smart) => {
+      this.setState({ fhirServer: smart.server.serviceUrl });
+    });
+  }
+
+  handlePatientSelect(patient) {
+    SMARTWrap.loadResources(patient.id).then(([conditions, medications, procedures, observations]) => {
+      this.props.setResources(conditions, medications, procedures, observations);
+    });
+    this.props.setPatient(patient);
+    this.props.gotoStep('Pronouncing');
+  }
+
+  render() {
+    return <PatientSearch smart handlePatientSelect={this.handlePatientSelect} fhirServer={this.state.fhirServer} />;
+  }
+
+}
+
+export default StandalonePatientSearch;

--- a/src/StandalonePatientSearch.js
+++ b/src/StandalonePatientSearch.js
@@ -2,11 +2,6 @@ import React, { Component } from 'react';
 import { SMARTWrap } from './FHIRClientWrapper';
 import PatientSearch from './PatientSearch';
 
-// fhirclient seems pretty broken from this perspective, it doesn't
-// export anything and it puts FHIR in window; work around for now
-import nothing from 'fhirclient'; // eslint-disable-line no-unused-vars
-const FHIR = window.FHIR;
-
 class StandalonePatientSearch extends Component {
 
   constructor(props) {
@@ -16,7 +11,7 @@ class StandalonePatientSearch extends Component {
   }
 
   componentWillMount() {
-    FHIR.oauth2.ready((smart) => {
+    SMARTWrap.ready().then((smart) => {
       this.setState({ fhirServer: smart.server.serviceUrl });
     });
   }

--- a/src/Welcome.js
+++ b/src/Welcome.js
@@ -1,77 +1,39 @@
 import React, { Component } from 'react';
-import { Form, Button, Loader, Card } from 'semantic-ui-react';
-import { FHIRWrap } from './FHIRClientWrapper';
+import { Menu } from 'semantic-ui-react';
+import WelcomePlain from './WelcomePlain';
+import WelcomeSmart from './WelcomeSmart';
 
 class Welcome extends Component {
 
   constructor(props) {
     super(props);
-    this.state = { fhirServer: 'https://syntheticmass.mitre.org/fhir', decedentName: '' };
-    this.handleChange = this.handleChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.handlePatientClick = this.handlePatientClick.bind(this);
+    this.state = { selectedMenuItem: 'plain' };
+    this.handleMenuClick = this.handleMenuClick.bind(this);
   }
 
-  handleChange(event) {
-    const target = event.target;
-    this.setState({
-      [target.name]: target.value
-    });
-  }
-
-  handleSubmit(event) {
-    event.preventDefault();
-    this.setState({ patients: [] });
-    FHIRWrap.loadPatients(this.state.fhirServer, this.state.decedentName).then((patients) => {
-      this.setState({ patients });
-    });
-  }
-
-  handlePatientClick(event, data) {
-    event.preventDefault();
-    const patient = this.state.patients.find((patient) => patient.id === data.id);
-    FHIRWrap.loadResources(this.state.fhirServer, patient.id).then(([conditions, medications, procedures, observations]) => {
-      this.props.setResources(conditions, medications, procedures, observations);
-    });
-    this.props.setPatient(patient);
-    this.props.gotoStep('Pronouncing');
+  handleMenuClick(event, data) {
+    this.setState({ selectedMenuItem: data.name });
   }
 
   render() {
-
-    const patientLink = (patient) => {
-      return <Card key={patient.id} onClick={this.handlePatientClick} id={patient.id} header={patient.name} />;
-    };
-
-    const patientLinks = (patients) => {
-      if (!patients) {
-        return null;
-      } else if (patients.length === 0) {
-        return <Loader active inline='centered' content='Loading' />;
-      } else {
-        return <Card.Group className='patients'>{patients.map(patientLink)}</Card.Group>;
-      }
-    };
-
+    const { selectedMenuItem } = this.state;
     return (
       <div>
         <h2>Welcome</h2>
-        <p>This prototype application was developed as a collaboration between the <a href="http://miblab.bme.gatech.edu">Wang Lab</a> at Georgia Tech's Wallace H. Coulter Department of Biomedical Engineering and the Centers for Disease Control.</p>
-        <p>The purpose of this application is to provide visualization, context, and decision support at the point of a patient's death, with the aim of improving the timeliness, accuracy, and completeness of mortality reporting.</p>
-        <h2>Search for Decedent Record</h2>
-        <h3>Specify FHIR server and patient name to search for</h3>
-        <Form onSubmit={this.handleSubmit}>
-          <Form.Field>
-            <label>FHIR server:</label>
-            <input type="text" name="fhirServer" value={this.state.fhirServer} onChange={this.handleChange} />
-          </Form.Field>
-          <Form.Field>
-            <label>Decedent name:</label>
-            <input type="text" name="decedentName" value={this.state.decedentName} onChange={this.handleChange} />
-          </Form.Field>
-          <Button primary type="submit">Search</Button>
-        </Form>
-        {patientLinks(this.state.patients)}
+        <p>The purpose of this application is to provide visualization, context, and decision support at the point of a patient's death, with the aim of improving the timeliness, accuracy, and completeness of mortality reporting. Source code and documentation can be <a href="https://github.com/nightingaleproject/fhir-death-refactor">found on GitHub</a>.</p>
+        <Menu pointing>
+          <Menu.Item name='plain'
+                     active={selectedMenuItem === 'plain'}
+                     onClick={this.handleMenuClick}>
+            Connect to a plain FHIR server
+          </Menu.Item>
+          <Menu.Item name='smart'
+                     active={selectedMenuItem === 'smart'}
+                     onClick={this.handleMenuClick}>
+            SMART on FHIR standalone launch
+          </Menu.Item>
+        </Menu>
+        { selectedMenuItem === 'plain' ? <WelcomePlain {...this.props}/> : <WelcomeSmart {...this.props}/> }
       </div>
     );
   }

--- a/src/WelcomePlain.js
+++ b/src/WelcomePlain.js
@@ -1,35 +1,19 @@
 import React, { Component } from 'react';
-import { Form, Button, Loader, Card } from 'semantic-ui-react';
 import { FHIRWrap } from './FHIRClientWrapper';
+import PatientSearch from './PatientSearch';
+
+const defaultFhirServer = 'https://syntheticmass.mitre.org/fhir';
 
 class Welcome extends Component {
 
   constructor(props) {
     super(props);
-    this.state = { fhirServer: 'https://syntheticmass.mitre.org/fhir', decedentName: '' };
-    this.handleChange = this.handleChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.handlePatientClick = this.handlePatientClick.bind(this);
+    this.state = { fhirServer: defaultFhirServer, decedentName: '' };
+    this.handlePatientSelect = this.handlePatientSelect.bind(this);
+    this.updateFhirServer = this.updateFhirServer.bind(this);
   }
 
-  handleChange(event) {
-    const target = event.target;
-    this.setState({
-      [target.name]: target.value
-    });
-  }
-
-  handleSubmit(event) {
-    event.preventDefault();
-    this.setState({ patients: [] });
-    FHIRWrap.loadPatients(this.state.fhirServer, this.state.decedentName).then((patients) => {
-      this.setState({ patients });
-    });
-  }
-
-  handlePatientClick(event, data) {
-    event.preventDefault();
-    const patient = this.state.patients.find((patient) => patient.id === data.id);
+  handlePatientSelect(patient) {
     FHIRWrap.loadResources(this.state.fhirServer, patient.id).then(([conditions, medications, procedures, observations]) => {
       this.props.setResources(conditions, medications, procedures, observations);
     });
@@ -37,39 +21,14 @@ class Welcome extends Component {
     this.props.gotoStep('Pronouncing');
   }
 
+  updateFhirServer(fhirServer) {
+    this.setState({ fhirServer });
+  }
+
   render() {
-
-    const patientLink = (patient) => {
-      return <Card key={patient.id} onClick={this.handlePatientClick} id={patient.id} header={patient.name} />;
-    };
-
-    const patientLinks = (patients) => {
-      if (!patients) {
-        return null;
-      } else if (patients.length === 0) {
-        return <Loader active inline='centered' content='Loading' />;
-      } else {
-        return <Card.Group className='patients'>{patients.map(patientLink)}</Card.Group>;
-      }
-    };
-
-    return (
-      <div>
-        <h3>Specify FHIR server and patient name to search for</h3>
-        <Form onSubmit={this.handleSubmit}>
-          <Form.Field>
-            <label>FHIR server:</label>
-            <input type="text" name="fhirServer" value={this.state.fhirServer} onChange={this.handleChange} />
-          </Form.Field>
-          <Form.Field>
-            <label>Decedent name:</label>
-            <input type="text" name="decedentName" value={this.state.decedentName} onChange={this.handleChange} />
-          </Form.Field>
-          <Button primary type="submit">Search</Button>
-        </Form>
-        {patientLinks(this.state.patients)}
-      </div>
-    );
+    return <PatientSearch handlePatientSelect={this.handlePatientSelect}
+                          updateFhirServer={this.updateFhirServer}
+                          fhirServer={this.state.fhirServer} />;
   }
 
 }

--- a/src/WelcomePlain.js
+++ b/src/WelcomePlain.js
@@ -1,0 +1,77 @@
+import React, { Component } from 'react';
+import { Form, Button, Loader, Card } from 'semantic-ui-react';
+import { FHIRWrap } from './FHIRClientWrapper';
+
+class Welcome extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { fhirServer: 'https://syntheticmass.mitre.org/fhir', decedentName: '' };
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handlePatientClick = this.handlePatientClick.bind(this);
+  }
+
+  handleChange(event) {
+    const target = event.target;
+    this.setState({
+      [target.name]: target.value
+    });
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    this.setState({ patients: [] });
+    FHIRWrap.loadPatients(this.state.fhirServer, this.state.decedentName).then((patients) => {
+      this.setState({ patients });
+    });
+  }
+
+  handlePatientClick(event, data) {
+    event.preventDefault();
+    const patient = this.state.patients.find((patient) => patient.id === data.id);
+    FHIRWrap.loadResources(this.state.fhirServer, patient.id).then(([conditions, medications, procedures, observations]) => {
+      this.props.setResources(conditions, medications, procedures, observations);
+    });
+    this.props.setPatient(patient);
+    this.props.gotoStep('Pronouncing');
+  }
+
+  render() {
+
+    const patientLink = (patient) => {
+      return <Card key={patient.id} onClick={this.handlePatientClick} id={patient.id} header={patient.name} />;
+    };
+
+    const patientLinks = (patients) => {
+      if (!patients) {
+        return null;
+      } else if (patients.length === 0) {
+        return <Loader active inline='centered' content='Loading' />;
+      } else {
+        return <Card.Group className='patients'>{patients.map(patientLink)}</Card.Group>;
+      }
+    };
+
+    return (
+      <div>
+        <h3>Specify FHIR server and patient name to search for</h3>
+        <Form onSubmit={this.handleSubmit}>
+          <Form.Field>
+            <label>FHIR server:</label>
+            <input type="text" name="fhirServer" value={this.state.fhirServer} onChange={this.handleChange} />
+          </Form.Field>
+          <Form.Field>
+            <label>Decedent name:</label>
+            <input type="text" name="decedentName" value={this.state.decedentName} onChange={this.handleChange} />
+          </Form.Field>
+          <Button primary type="submit">Search</Button>
+        </Form>
+        {patientLinks(this.state.patients)}
+      </div>
+    );
+  }
+
+}
+
+export default Welcome;

--- a/src/WelcomeSmart.js
+++ b/src/WelcomeSmart.js
@@ -1,0 +1,74 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import { Form, Button } from 'semantic-ui-react';
+import Loading from './Loading';
+
+// fhirclient seems pretty broken from this perspective, it doesn't
+// export anything and it puts FHIR in window; work around for now
+import nothing from 'fhirclient'; // eslint-disable-line no-unused-vars
+const FHIR = window.FHIR;
+
+const redirectURI = window.location.href + 'smart'
+
+class WelcomeSmart extends Component {
+
+  constructor(props) {
+    super(props);
+    // See if we have state from previous use stored in local browser storage
+    const localState = localStorage['stateWelcomeSmart'];
+    this.state = localState ? JSON.parse(localState) : { fhirServer: '', clientId: '', secret: '' };
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleChange(event) {
+    const target = event.target;
+    this.setState({ [target.name]: target.value }, () => {
+      // Store all state in local browser storage too to preserve between uses
+      localStorage['stateWelcomeSmart'] = JSON.stringify(this.state);
+    });
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    const server = this.state.fhirServer;
+    const client = {
+      scope: 'patient/*.read user/Patient.read launch openid profile online_access',
+      client_id: this.state.clientId,
+      redirect_uri: redirectURI
+    }
+    if (this.state.secret) {
+      client['secret'] = this.state.secret;
+    }
+    FHIR.oauth2.authorize({ server: server, client: client });
+    ReactDOM.render(<Loading />, document.getElementById('root'));
+  }
+
+  render() {
+    return (
+      <div>
+        <h3>Specify information for the SMART on FHIR server to launch against</h3>
+        <Form onSubmit={this.handleSubmit}>
+          <Form.Field>
+            <label>FHIR server:</label>
+            <input type="text" name="fhirServer" value={this.state.fhirServer} onChange={this.handleChange} />
+          </Form.Field>
+          <Form.Field>
+            <label>Client ID:</label>
+            <input type="text" name="clientId" value={this.state.clientId} onChange={this.handleChange} />
+          </Form.Field>
+          <Form.Field>
+            <label>Secret (if needed):</label>
+            <input type="text" name="secret" value={this.state.secret} onChange={this.handleChange} />
+          </Form.Field>
+          <p>Note: Specify <tt>{redirectURI}</tt> as the redirect URL on the SMART on FHIR server.</p>
+          <p>Note: The information you enter above is stored in your local browser state to make it available across uses.</p>
+          <Button primary type="submit">Connect</Button>
+        </Form>
+      </div>
+    );
+  }
+
+}
+
+export default WelcomeSmart;

--- a/src/WelcomeSmart.js
+++ b/src/WelcomeSmart.js
@@ -8,7 +8,7 @@ import Loading from './Loading';
 import nothing from 'fhirclient'; // eslint-disable-line no-unused-vars
 const FHIR = window.FHIR;
 
-const redirectURI = window.location.href + 'smart'
+const redirectURI = window.location.href + 'standalone'
 
 class WelcomeSmart extends Component {
 

--- a/src/WelcomeSmart.js
+++ b/src/WelcomeSmart.js
@@ -1,12 +1,8 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import { Form, Button } from 'semantic-ui-react';
+import { SMARTWrap } from './FHIRClientWrapper';
 import Loading from './Loading';
-
-// fhirclient seems pretty broken from this perspective, it doesn't
-// export anything and it puts FHIR in window; work around for now
-import nothing from 'fhirclient'; // eslint-disable-line no-unused-vars
-const FHIR = window.FHIR;
 
 const redirectURI = window.location.href + 'standalone'
 
@@ -40,7 +36,7 @@ class WelcomeSmart extends Component {
     if (this.state.secret) {
       client['secret'] = this.state.secret;
     }
-    FHIR.oauth2.authorize({ server: server, client: client });
+    SMARTWrap.authorize({ server: server, client: client });
     ReactDOM.render(<Loading />, document.getElementById('root'));
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,9 @@ case 'launch':
 case 'smart':
   ReactDOM.render(<App smart/>, document.getElementById('root'));
   break;
+case 'standalone':
+  ReactDOM.render(<App standalone/>, document.getElementById('root'));
+  break;
 default:
   ReactDOM.render(<App />, document.getElementById('root'));
   break;

--- a/src/index.js
+++ b/src/index.js
@@ -7,11 +7,7 @@ import './index.css';
 import Loading from './Loading';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
-
-// fhirclient seems pretty broken from this perspective, it doesn't
-// export anything and it puts FHIR in window; work around for now
-import nothing from 'fhirclient'; // eslint-disable-line no-unused-vars
-const FHIR = window.FHIR;
+import { SMARTWrap } from './FHIRClientWrapper';
 
 // See if we're being launched from within a SMART on FHIR context
 switch (_.last(window.location.pathname.split('/'))) {
@@ -20,7 +16,7 @@ case 'launch':
   const clientId = '17eff9ba-9445-426f-a457-b49ee385464e';
   const launchUri = window.location.protocol + "//" + window.location.host + window.location.pathname;
   const redirectUri = launchUri.replace('launch', 'smart');
-  FHIR.oauth2.authorize({ client_id: clientId, scope: scope, redirect_uri: redirectUri });
+  SMARTWrap.authorize({ client_id: clientId, scope: scope, redirect_uri: redirectUri });
   ReactDOM.render(<Loading />, document.getElementById('root'));
   break;
 case 'smart':

--- a/yarn.lock
+++ b/yarn.lock
@@ -2599,6 +2599,7 @@ fbjs@^0.8.16:
 fhirclient@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/fhirclient/-/fhirclient-0.1.12.tgz#d9529de1f5c63b76120038a6898382bfc500d916"
+  integrity sha1-2VKd4fXGO3YSADimiYOCv8UA2RY=
 
 figures@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,14 @@
   version "9.6.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.2.tgz#e49ac1adb458835e95ca6487bc20f916b37aff23"
 
+JSONStream@^1.0.3:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -27,6 +35,11 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
+acorn-dynamic-import@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
+  integrity sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==
+
 acorn-globals@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
@@ -39,6 +52,21 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
+acorn-node@^1.2.0, acorn-node@^1.3.0, acorn-node@^1.5.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.6.2.tgz#b7d7ceca6f22e6417af933a62cad4de01048d5d2"
+  integrity sha512-rIhNEZuNI8ibQcL7ANm/mGyPukIaZsRNX9psFNQURyJW0nu6k8wjSDld20z6v2mDBWqX13pIEnk9gGZJHIlEXg==
+  dependencies:
+    acorn "^6.0.2"
+    acorn-dynamic-import "^4.0.0"
+    acorn-walk "^6.1.0"
+    xtend "^4.0.1"
+
+acorn-walk@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
+  integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
+
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
@@ -50,6 +78,11 @@ acorn@^4.0.3, acorn@^4.0.4:
 acorn@^5.0.0, acorn@^5.4.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
+
+acorn@^6.0.2:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.5.tgz#81730c0815f3f3b34d8efa95cb7430965f4d887a"
+  integrity sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==
 
 address@1.0.3, address@^1.0.1:
   version "1.0.3"
@@ -251,9 +284,10 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-assert@^1.1.1:
+assert@^1.1.1, assert@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
+  integrity sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=
   dependencies:
     util "0.10.3"
 
@@ -1081,6 +1115,25 @@ brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
+browser-pack@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/browser-pack/-/browser-pack-6.1.0.tgz#c34ba10d0b9ce162b5af227c7131c92c2ecd5774"
+  integrity sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==
+  dependencies:
+    JSONStream "^1.0.3"
+    combine-source-map "~0.8.0"
+    defined "^1.0.0"
+    safe-buffer "^5.1.1"
+    through2 "^2.0.0"
+    umd "^3.0.0"
+
+browser-resolve@^1.11.0, browser-resolve@^1.7.0:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
+  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
+  dependencies:
+    resolve "1.1.7"
+
 browser-resolve@^1.11.2:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
@@ -1133,11 +1186,66 @@ browserify-sign@^4.0.0:
     inherits "^2.0.1"
     parse-asn1 "^5.0.0"
 
-browserify-zlib@^0.2.0:
+browserify-zlib@^0.2.0, browserify-zlib@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
+  integrity sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   dependencies:
     pako "~1.0.5"
+
+browserify@^16.2.3:
+  version "16.2.3"
+  resolved "https://registry.yarnpkg.com/browserify/-/browserify-16.2.3.tgz#7ee6e654ba4f92bce6ab3599c3485b1cc7a0ad0b"
+  integrity sha512-zQt/Gd1+W+IY+h/xX2NYMW4orQWhqSwyV+xsblycTtpOuB27h1fZhhNQuipJ4t79ohw4P4mMem0jp/ZkISQtjQ==
+  dependencies:
+    JSONStream "^1.0.3"
+    assert "^1.4.0"
+    browser-pack "^6.0.1"
+    browser-resolve "^1.11.0"
+    browserify-zlib "~0.2.0"
+    buffer "^5.0.2"
+    cached-path-relative "^1.0.0"
+    concat-stream "^1.6.0"
+    console-browserify "^1.1.0"
+    constants-browserify "~1.0.0"
+    crypto-browserify "^3.0.0"
+    defined "^1.0.0"
+    deps-sort "^2.0.0"
+    domain-browser "^1.2.0"
+    duplexer2 "~0.1.2"
+    events "^2.0.0"
+    glob "^7.1.0"
+    has "^1.0.0"
+    htmlescape "^1.1.0"
+    https-browserify "^1.0.0"
+    inherits "~2.0.1"
+    insert-module-globals "^7.0.0"
+    labeled-stream-splicer "^2.0.0"
+    mkdirp "^0.5.0"
+    module-deps "^6.0.0"
+    os-browserify "~0.3.0"
+    parents "^1.0.1"
+    path-browserify "~0.0.0"
+    process "~0.11.0"
+    punycode "^1.3.2"
+    querystring-es3 "~0.2.0"
+    read-only-stream "^2.0.0"
+    readable-stream "^2.0.2"
+    resolve "^1.1.4"
+    shasum "^1.0.0"
+    shell-quote "^1.6.1"
+    stream-browserify "^2.0.0"
+    stream-http "^2.0.0"
+    string_decoder "^1.1.1"
+    subarg "^1.0.0"
+    syntax-error "^1.1.1"
+    through2 "^2.0.0"
+    timers-browserify "^1.0.1"
+    tty-browserify "0.0.1"
+    url "~0.11.0"
+    util "~0.10.1"
+    vm-browserify "^1.0.0"
+    xtend "^4.0.0"
 
 browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
   version "1.7.7"
@@ -1165,6 +1273,21 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+btoa@*:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
 buffer-indexof@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
@@ -1181,6 +1304,14 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.0.2:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
+  integrity sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -1192,6 +1323,11 @@ builtin-status-codes@^3.0.0:
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+
+cached-path-relative@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cached-path-relative/-/cached-path-relative-1.0.2.tgz#a13df4196d26776220cc3356eb147a52dba2c6db"
+  integrity sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -1440,6 +1576,16 @@ colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
+combine-source-map@^0.8.0, combine-source-map@~0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/combine-source-map/-/combine-source-map-0.8.0.tgz#a58d0df042c186fcf822a8e8015f5450d2d79a8b"
+  integrity sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=
+  dependencies:
+    convert-source-map "~1.1.0"
+    inline-source-map "~0.6.0"
+    lodash.memoize "~3.0.3"
+    source-map "~0.5.3"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -1492,6 +1638,16 @@ concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+concat-stream@^1.6.1, concat-stream@~1.6.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
 configstore@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.1.tgz#094ee662ab83fad9917678de114faaea8fcdca90"
@@ -1517,9 +1673,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-constants-browserify@^1.0.0:
+constants-browserify@^1.0.0, constants-browserify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
+  integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
 contains-path@^0.1.0:
   version "0.1.0"
@@ -1540,6 +1697,11 @@ content-type@~1.0.4:
 convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
+
+convert-source-map@~1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.1.3.tgz#4829c877e9fe49b3161f3bf3673888e204699860"
+  integrity sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -1630,9 +1792,10 @@ cryptiles@3.x.x:
   dependencies:
     boom "5.x.x"
 
-crypto-browserify@^3.11.0:
+crypto-browserify@^3.0.0, crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
+  integrity sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
   dependencies:
     browserify-cipher "^1.0.0"
     browserify-sign "^4.0.0"
@@ -1862,6 +2025,16 @@ depd@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
+deps-sort@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/deps-sort/-/deps-sort-2.0.0.tgz#091724902e84658260eb910748cccd1af6e21fb5"
+  integrity sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=
+  dependencies:
+    JSONStream "^1.0.3"
+    shasum "^1.0.0"
+    subarg "^1.0.0"
+    through2 "^2.0.0"
+
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
@@ -1893,6 +2066,15 @@ detect-port-alt@1.1.5:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+detective@^5.0.2:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/detective/-/detective-5.1.0.tgz#7a20d89236d7b331ccea65832e7123b5551bb7cb"
+  integrity sha512-TFHMqfOvxlgrfVzTEkNBSh9SvSNX/HfF4OFI2QFGCyPm02EsyILqnUeb5P6q7JZ3SFNTBL5t2sePRgrN4epUWQ==
+  dependencies:
+    acorn-node "^1.3.0"
+    defined "^1.0.0"
+    minimist "^1.1.1"
 
 diff@^3.2.0:
   version "3.4.0"
@@ -1959,9 +2141,10 @@ dom-urls@^1.1.0:
   dependencies:
     urijs "^1.16.1"
 
-domain-browser@^1.1.1:
+domain-browser@^1.1.1, domain-browser@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
+  integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
 domelementtype@1, domelementtype@^1.3.0:
   version "1.3.0"
@@ -2017,6 +2200,13 @@ dotenv@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
 
+duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
+  integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
+  dependencies:
+    readable-stream "^2.0.2"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -2030,6 +2220,13 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+ecdsa-sig-formatter@1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz#1c595000f04a8897dfb85000892a0f4c33af86c3"
+  integrity sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2425,6 +2622,11 @@ events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
+events@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-2.1.0.tgz#2a9a1e18e6106e0e812aa9ebd4a819b3c29c0ba5"
+  integrity sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==
+
 eventsource@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-0.1.6.tgz#0acede849ed7dd1ccc32c811bb11b944d4f29232"
@@ -2596,10 +2798,14 @@ fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fhirclient@^0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/fhirclient/-/fhirclient-0.1.12.tgz#d9529de1f5c63b76120038a6898382bfc500d916"
-  integrity sha1-2VKd4fXGO3YSADimiYOCv8UA2RY=
+fhirclient@nightingaleproject/client-js#bugfix:
+  version "0.1.0"
+  resolved "https://codeload.github.com/nightingaleproject/client-js/tar.gz/e92eefd6c992292d7861872268ebd59054d232ef"
+  dependencies:
+    browserify "^16.2.3"
+    btoa "*"
+    jquery "^3.3.1"
+    jsonwebtoken "^8.4.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -2832,6 +3038,11 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+get-assigned-identifiers@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz#6dbf411de648cbaf8d9169ebb0d2d576191e2ff1"
+  integrity sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==
+
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
@@ -2878,6 +3089,18 @@ glob-parent@^2.0.0:
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.0:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -3023,6 +3246,13 @@ has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
+has@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
+
 has@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
@@ -3150,6 +3380,11 @@ html-webpack-plugin@2.29.0:
     lodash "^4.17.3"
     pretty-error "^2.0.2"
     toposort "^1.0.0"
+
+htmlescape@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/htmlescape/-/htmlescape-1.1.1.tgz#3a03edc2214bca3b66424a3e7959349509cb0351"
+  integrity sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=
 
 htmlparser2@^3.9.1:
   version "3.9.2"
@@ -3294,6 +3529,13 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
+inline-source-map@~0.6.0:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/inline-source-map/-/inline-source-map-0.6.2.tgz#f9393471c18a79d1724f863fa38b586370ade2a5"
+  integrity sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=
+  dependencies:
+    source-map "~0.5.3"
+
 inquirer@3.3.0, inquirer@^3.0.6:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
@@ -3312,6 +3554,22 @@ inquirer@3.3.0, inquirer@^3.0.6:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
+
+insert-module-globals@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/insert-module-globals/-/insert-module-globals-7.2.0.tgz#ec87e5b42728479e327bd5c5c71611ddfb4752ba"
+  integrity sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==
+  dependencies:
+    JSONStream "^1.0.3"
+    acorn-node "^1.5.2"
+    combine-source-map "^0.8.0"
+    concat-stream "^1.6.1"
+    is-buffer "^1.1.0"
+    path-is-absolute "^1.0.1"
+    process "~0.11.0"
+    through2 "^2.0.0"
+    undeclared-identifiers "^1.1.2"
+    xtend "^4.0.0"
 
 internal-ip@1.2.0:
   version "1.2.0"
@@ -3359,9 +3617,10 @@ is-boolean-object@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.0, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
@@ -3567,6 +3826,11 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isarray@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.4.tgz#38e7bcbb0f3ba1b7933c86ba1894ddfc3781bbb7"
+  integrity sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -3863,9 +4127,10 @@ jest@20.0.4:
   dependencies:
     jest-cli "^20.0.4"
 
-jquery@x.*:
+jquery@^3.3.1, jquery@x.*:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
 
 js-base64@^2.1.9:
   version "2.4.3"
@@ -3943,6 +4208,13 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
+json-stable-stringify@~0.0.0:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz#611c23e814db375527df851193db59dd2af27f45"
+  integrity sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -3977,6 +4249,26 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
+jsonparse@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
+  integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
+
+jsonwebtoken@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz#8757f7b4cb7440d86d5e2f3becefa70536c8e46a"
+  integrity sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==
+  dependencies:
+    jws "^3.1.5"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -3995,6 +4287,23 @@ jsx-ast-utils@^2.0.0:
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
+
+jwa@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.6.tgz#87240e76c9808dbde18783cf2264ef4929ee50e6"
+  integrity sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.10"
+    safe-buffer "^5.0.1"
+
+jws@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.5.tgz#80d12d05b293d1e841e7cb8b4e69e561adcf834f"
+  integrity sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==
+  dependencies:
+    jwa "^1.1.5"
+    safe-buffer "^5.0.1"
 
 killable@^1.0.0:
   version "1.0.0"
@@ -4017,6 +4326,15 @@ klaw@^1.0.0:
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
   optionalDependencies:
     graceful-fs "^4.1.9"
+
+labeled-stream-splicer@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz#9cffa32fd99e1612fd1d86a8db962416d5292926"
+  integrity sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==
+  dependencies:
+    inherits "^2.0.1"
+    isarray "^2.0.4"
+    stream-splicer "^2.0.0"
 
 latest-version@^3.0.0:
   version "3.1.0"
@@ -4119,9 +4437,49 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
+lodash.memoize@~3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
+  integrity sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.template@^4.4.0:
   version "4.4.0"
@@ -4330,7 +4688,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -4338,11 +4696,33 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+module-deps@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-6.2.0.tgz#d41a2e790245ce319171e4e7c4d8c73993ba3cd5"
+  integrity sha512-hKPmO06so6bL/ZvqVNVqdTVO8UAYsi3tQWlCa+z9KuWhoN4KDQtb5hcqQQv58qYiDE21wIvnttZEPiDgEbpwbA==
+  dependencies:
+    JSONStream "^1.0.3"
+    browser-resolve "^1.7.0"
+    cached-path-relative "^1.0.0"
+    concat-stream "~1.6.0"
+    defined "^1.0.0"
+    detective "^5.0.2"
+    duplexer2 "^0.1.2"
+    inherits "^2.0.1"
+    parents "^1.0.0"
+    readable-stream "^2.0.2"
+    resolve "^1.4.0"
+    stream-combiner2 "^1.1.1"
+    subarg "^1.0.0"
+    through2 "^2.0.0"
+    xtend "^4.0.0"
 
 moment@^2.20.1:
   version "2.20.1"
@@ -4351,6 +4731,11 @@ moment@^2.20.1:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -4657,9 +5042,10 @@ original@>=0.0.5:
   dependencies:
     url-parse "1.0.x"
 
-os-browserify@^0.3.0:
+os-browserify@^0.3.0, os-browserify@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
+  integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
 
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
@@ -4733,6 +5119,13 @@ param-case@2.1.x:
   dependencies:
     no-case "^2.2.0"
 
+parents@^1.0.0, parents@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parents/-/parents-1.0.1.tgz#fedd4d2bf193a77745fe71e371d73c3307d9c751"
+  integrity sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=
+  dependencies:
+    path-platform "~0.11.15"
+
 parse-asn1@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.0.tgz#37c4f9b7ed3ab65c74817b5f2480937fbf97c712"
@@ -4780,6 +5173,11 @@ path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
 
+path-browserify@~0.0.0:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
+  integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -4805,6 +5203,16 @@ path-key@^2.0.0:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-platform@~0.11.15:
+  version "0.11.15"
+  resolved "https://registry.yarnpkg.com/path-platform/-/path-platform-0.11.15.tgz#e864217f74c36850f0852b78dc7bf7d4a5721bf2"
+  integrity sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -5212,9 +5620,15 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-process@^0.11.10:
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+  integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
+
+process@^0.11.10, process@~0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 progress@^2.0.0:
   version "2.0.0"
@@ -5269,9 +5683,10 @@ punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
 
-punycode@^1.2.4, punycode@^1.4.1:
+punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
 q@^1.1.2:
   version "1.5.1"
@@ -5292,9 +5707,10 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-querystring-es3@^0.2.0:
+querystring-es3@^0.2.0, querystring-es3@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
+  integrity sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=
 
 querystring@0.2.0:
   version "0.2.0"
@@ -5478,6 +5894,13 @@ react@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+read-only-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-only-stream/-/read-only-stream-2.0.0.tgz#2724fd6a8113d73764ac288d4386270c1dbf17f0"
+  integrity sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=
+  dependencies:
+    readable-stream "^2.0.2"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -5527,6 +5950,19 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable
     process-nextick-args "~1.0.6"
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.3.6, readable-stream@~2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
@@ -5760,6 +6196,13 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
+resolve@^1.1.4, resolve@^1.4.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
+  integrity sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@^1.3.2, resolve@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
@@ -5951,6 +6394,22 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+sha.js@~2.4.4:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
+shasum@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shasum/-/shasum-1.0.2.tgz#e7012310d8f417f4deb5712150e5678b87ae565f"
+  integrity sha1-5wEjENj0F/TetXEhUOVni4euVl8=
+  dependencies:
+    json-stable-stringify "~0.0.0"
+    sha.js "~2.4.4"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -5961,9 +6420,10 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shell-quote@1.6.1:
+shell-quote@1.6.1, shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
+  integrity sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=
   dependencies:
     array-filter "~0.0.0"
     array-map "~0.0.0"
@@ -5977,6 +6437,11 @@ shellwords@^0.1.1:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-concat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
+  integrity sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=
 
 slash@^1.0.0:
   version "1.0.0"
@@ -6034,9 +6499,10 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1, source-map@~0.5.6:
+source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1, source-map@~0.5.3, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -6111,12 +6577,32 @@ statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 
-stream-browserify@^2.0.1:
+stream-browserify@^2.0.0, stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
+  integrity sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
+
+stream-combiner2@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stream-combiner2/-/stream-combiner2-1.1.1.tgz#fb4d8a1420ea362764e21ad4780397bebcb41cbe"
+  integrity sha1-+02KFCDqNidk4hrUeAOXvry0HL4=
+  dependencies:
+    duplexer2 "~0.1.0"
+    readable-stream "^2.0.2"
+
+stream-http@^2.0.0:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.8.3.tgz#b2d242469288a5a27ec4fe8933acf623de6514fc"
+  integrity sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==
+  dependencies:
+    builtin-status-codes "^3.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.3.6"
+    to-arraybuffer "^1.0.0"
+    xtend "^4.0.0"
 
 stream-http@^2.7.2:
   version "2.8.0"
@@ -6127,6 +6613,14 @@ stream-http@^2.7.2:
     readable-stream "^2.3.3"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+stream-splicer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stream-splicer/-/stream-splicer-2.0.0.tgz#1b63be438a133e4b671cc1935197600175910d83"
+  integrity sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -6159,9 +6653,23 @@ string_decoder@^1.0.0, string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
+  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
 
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
@@ -6209,6 +6717,13 @@ style-loader@0.19.0:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
+
+subarg@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
+  integrity sha1-9izxdYHplrSPyWVpn1TAauJouNI=
+  dependencies:
+    minimist "^1.1.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -6278,6 +6793,13 @@ symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
+syntax-error@^1.1.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/syntax-error/-/syntax-error-1.4.0.tgz#2d9d4ff5c064acb711594a3e3b95054ad51d907c"
+  integrity sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==
+  dependencies:
+    acorn-node "^1.2.0"
+
 table@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
@@ -6338,9 +6860,18 @@ throat@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
 
-through@^2.3.6:
+through2@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
+
+"through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 thunky@^1.0.2:
   version "1.0.2"
@@ -6353,6 +6884,13 @@ time-stamp@^2.0.0:
 timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+
+timers-browserify@^1.0.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-1.4.2.tgz#c9c58b575be8407375cb5e2462dacee74359f41d"
+  integrity sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=
+  dependencies:
+    process "~0.11.0"
 
 timers-browserify@^2.0.4:
   version "2.0.6"
@@ -6403,6 +6941,11 @@ trim-right@^1.0.1:
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
+
+tty-browserify@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
+  integrity sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -6466,6 +7009,21 @@ uglifyjs-webpack-plugin@^0.4.6:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+umd@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.3.tgz#aa9fe653c42b9097678489c01000acb69f0b26cf"
+  integrity sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==
+
+undeclared-identifiers@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/undeclared-identifiers/-/undeclared-identifiers-1.1.2.tgz#7d850a98887cff4bd0bf64999c014d08ed6d1acc"
+  integrity sha512-13EaeocO4edF/3JKime9rD7oB6QI8llAGhgn5fKOPyfkJbRb6NFv9pYV6dFEmpa4uRjKeBqLZP8GpuzqHlKDMQ==
+  dependencies:
+    acorn-node "^1.3.0"
+    get-assigned-identifiers "^1.2.0"
+    simple-concat "^1.0.0"
+    xtend "^4.0.1"
 
 underscore@~1.4.4:
   version "1.4.4"
@@ -6553,9 +7111,10 @@ url-parse@^1.1.8:
     querystringify "~1.0.0"
     requires-port "~1.0.0"
 
-url@^0.11.0:
+url@^0.11.0, url@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
@@ -6569,6 +7128,13 @@ util@0.10.3, util@^0.10.3:
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
     inherits "2.0.1"
+
+util@~0.10.1:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
 
 utila@~0.3:
   version "0.3.3"
@@ -6618,6 +7184,11 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+vm-browserify@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
+  integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
 
 walker@~1.0.5:
   version "1.0.7"
@@ -6852,7 +7423,7 @@ xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
-xtend@^4.0.0, xtend@^4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
This pull request

1) Supports launching the app as a standalone SMART on FHIR app, alongside the previous EHR launch and non-SMART FHIR approaches, storing some application state in browser local storage

2) Adds some flexibility in supporting MedicationRequest or MedicationOrder, which will let us run against DSTU2 and STU3 servers

3) Slightly refactors how the fhirclient library is used by further abstracting references to it

4) Fixes a bug in fhirclient by pointing to a fork instead